### PR TITLE
Allowed a more relaxed PyYaml requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ repository = 'https://github.com/SiggiGue/hdfdict'
 [tool.poetry.dependencies]
 python = "^3.7"
 h5py-wrapper = "^1.1"
-pyyaml = "^5.1"
+pyyaml = ">=5.1"
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^2.7"


### PR DESCRIPTION
I hope this small change is alright with you. PyYaml has version 6.0. This allows more newer Python enviroments to still use this package.

Feel free to change anything you wish in this PR.